### PR TITLE
Repairs unproperly escaped $row -> attachold in edit.php

### DIFF
--- a/admin/views/article/tmpl/edit.php
+++ b/admin/views/article/tmpl/edit.php
@@ -1018,7 +1018,7 @@ if(COM_TZ_PORTFOLIO_JVERSION_COMPARE){
                 var myHidden = new Element('input',{
                     type:'hidden',
                     name:'tz_attachments_hidden_old[]',
-                    value:'<?php echo $row -> attachold;?>'
+                    value:'<?php echo htmlentities($row -> attachold,ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE | ENT_DISALLOWED,"UTF-8",false);?>'
                 }).inject(myTd);
 				var myTd = new Element('td',{
                     html:'<?php echo !empty($row -> attachtitle)? htmlentities($row -> attachtitle,ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE | ENT_DISALLOWED,"UTF-8",false): htmlentities($row -> attachold, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE | ENT_DISALLOWED, "UTF-8", false);?>'


### PR DESCRIPTION
Same probllem as before, this field had escaped my attention :)
in admin\views\article\tmpl?php

hidden field tz_attachment_hidden_old needed escaping in order to not
break javascript when a single quote is contained in the value
